### PR TITLE
removed "onlyLocals" attribute for css-loader ^4.0.0 support

### DIFF
--- a/withStyles.js
+++ b/withStyles.js
@@ -227,7 +227,6 @@ const getStyleLoaders = (
     options: {
       sourceMap: dev,
       importLoaders: loaders.length + (postcssLoader ? 1 : 0),
-      onlyLocals: isServer,
       modules: cssModules,
       ...cssLoaderOptions,
     },


### PR DESCRIPTION
This line provided issues when used with css-loader 4.0.0 and up. I don't think removing it will cause any new issues, though I have not tested it very thoroughly.